### PR TITLE
Update api.py - insert thread post to event

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -356,6 +356,12 @@ class PyMISP(object):
         response = session.post(urljoin(self.root_url, 'events/removeTag'), data=json.dumps(to_post))
         return self._check_response(response)
 
+    def insert_thread(self, event_id, thread):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'posts/add/event/{}'.format(event_id))
+        to_post = {'Post':{u'message':thread}}
+        session.post(url, data=json.dumps(to_post))
+        
     # ##### File attributes #####
 
     def _send_attributes(self, event, attributes, proposal=False):


### PR DESCRIPTION
'def insert_thread' will allow via api to insert a thread post to a specific event.  Useful for providing additional/full context to events in the form of additional 'freeform' notes.  
**NOTE** - there is no response or check since everytime I've tested this, I received a 500 error back, yet the the thread posts correctly upon refreshing the event page.  Example from error:


Example Python script of function in use:

```
from pymisp import PyMISP
from keys import misp_url, misp_key
import argparse

# For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
try:
    input = raw_input
except NameError:
    pass

def init(url, key):
    return PyMISP(url, key, True, 'json', debug=True)

if __name__ == '__main__':

    parser = argparse.ArgumentParser(description='Insert thread post to event')
    parser.add_argument("-e", "--event", required=True, help="Event ID to insert thread post into.")
    parser.add_argument("-t", "--thread", help="Thread post contents")

    args = parser.parse_args()

    misp = init(misp_url, misp_key)

    misp.insert_thread(args.event, args.thread)
```